### PR TITLE
Event Bridge Pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-bridge"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "patterns/component_installer",
     "patterns/deferred_spawn",
     "patterns/dependency_hook",
+    "patterns/event_bridge",
 ]

--- a/patterns/event_bridge/Cargo.toml
+++ b/patterns/event_bridge/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "event-bridge"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bevy = "0.14"

--- a/patterns/event_bridge/README.md
+++ b/patterns/event_bridge/README.md
@@ -1,0 +1,25 @@
+# Pattern Name: Event bridge
+
+## Description
+
+Send events between your plugins/systems without a shared event type (or other imports). This can make your plugins fully independent and exchangeable. The small amount of boilerplate per system will be dependent on the plugin, though. Making your plugins send/receive generic events allows a project to use an actual custom event type to be used in the ECS. This is done by translating before sending and after receiving an event.
+
+## Implementation
+
+[Implementation on both sides (event emitter and receiver plugins)](./src/main.rs)
+
+## Use cases
+
+This pattern is applied to plugins/systems making use of events. Such plugins can then be connected using a small amount of code within your project.
+
+You can use it to connect plugins in a very loose way without any of them knowing anything about the other. It does not introduce additional game cycles for the event transfer, but add some conversion overhead (usually very small). The connecting event can be fully customized.
+
+## Alternatives
+
+- Translation systems (a system function which receives all events of a given type and for each emits another type of event)
+- Accept dependencies (e.g. shared types) between (internal-only) plugins
+
+## Credit
+
+This makes use of [bevy's support for generics](https://bevy-cheatbook.github.io/patterns/generic-systems.html) and the [From-trait from the rust standard library](https://doc.rust-lang.org/std/convert/trait.From.html).
+

--- a/patterns/event_bridge/src/main.rs
+++ b/patterns/event_bridge/src/main.rs
@@ -1,0 +1,76 @@
+use bevy::prelude::*;
+use boilerplate::*;
+
+mod boilerplate {
+    use bevy::ecs::event::Event;
+
+    use super::event_actor::ActorEvent;
+    use super::event_emitter::EmitterEvent;
+    
+    #[derive(Event, Clone)]
+    /// Glue for the different event types of the plugins
+    pub struct GameEvent(pub &'static str);
+
+    impl From<EmitterEvent> for GameEvent {
+        fn from(other: EmitterEvent) -> Self {
+            Self(other.0)
+        }
+    }
+
+    impl From<GameEvent> for ActorEvent {
+        fn from(other: GameEvent) -> Self {
+            Self(other.0.len())
+        }
+    }
+}
+
+fn main() {
+    App::new()
+        .add_event::<GameEvent>()
+        .add_plugins(DefaultPlugins)
+        
+        // Note you can comment out each plugin without breaking code
+        .add_plugins(event_emitter::plugin::<GameEvent>)
+        .add_plugins(event_actor::plugin::<GameEvent>)
+        
+        .run();
+}
+
+mod event_actor {
+    // Note there is no import from the emitter
+    use bevy::ecs::event::Event;
+    use bevy::prelude::*;
+
+    #[derive(Event)]
+    pub struct ActorEvent(pub usize);
+
+    pub fn plugin<E: Event + Clone + Into<ActorEvent>>(app: &mut App) {
+        app.add_systems(Update, act::<E>);
+    }
+
+    fn act<E: Event + Clone + Into<ActorEvent>>(mut events_in: EventReader<E>) {
+        for event in events_in.read() {
+            // with this transformation we can act on all of the data of the event.
+            let event: ActorEvent = (*event).clone().into();
+            info!("Event: {}", event.0);
+        }
+    }
+}
+
+mod event_emitter {
+    // Note there is no import from the actor
+    use bevy::ecs::event::Event;
+    use bevy::prelude::*;
+
+    #[derive(Event)]
+    pub struct EmitterEvent(pub &'static str);
+
+    pub fn plugin<E: Event + From<EmitterEvent>>(app: &mut App) {
+        app.add_event::<EmitterEvent>()
+            .add_systems(PreUpdate, send::<E>);
+    }
+
+    fn send<E: Event + From<EmitterEvent>>(mut events_out: EventWriter<E>) {
+        events_out.send(E::from(EmitterEvent("my event")));
+    }
+}


### PR DESCRIPTION
This is about a pattern to make plugins (even internal ones) independent of other code, even in terms of imports.

https://github.com/Pfeil/bevy-design-patterns/tree/generic-events/patterns/event_bridge

Let's shortly define some properties / levels of independence of a plugin:

1. the initialization (add_plugins) can be omitted, and your code will still work without any other adjustments like removing imports.
2. the plugin can be fully removed, and your code will still work without any other adjustments like removing imports.

I was aiming for both properties. So far, it at least works in the example case. Not sure how it applies in practice. This is a really early idea.

Things which came to my mind, but I was not able to try yet:

- can it be applied to more than events? Like components or other types one would need to import?
- is a configuration resource an alternative, and in which cases?
- can we make a wrapper module which packs the boilerplate and the plugin module in order to further structure the imports in a hierarchical, useful way? (probably yes)
- I believe this is already useful if either the sender or the emitter implement the pattern, at least in one way. I did not try yet, though. We could add some examples, e.g., by using a src/bin folder.
- We have a clone in there, we can probably avoid it somehow.
- I'd like to test / see it in some greater context to see how it works in practice.